### PR TITLE
Small bugfix to Python 3 import guard

### DIFF
--- a/nose_capturestderr/__init__.py
+++ b/nose_capturestderr/__init__.py
@@ -21,9 +21,9 @@ import sys
 from nose.plugins.base import Plugin
 from nose.util import ln
 try:
-    from io import StringIO
-except ImportError:
     from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Unfortunately my Python 3 import guard fix from a while ago subtly broke things on Python 2.6+

Turns out Python 2.6+ contains a backport of Python 3's `io.StringIO`module that behaves differently than `StringIO.StringIO` in combination with strings and unicode. 

This PR fixes this problem by reversing the order in which the imports are attempted.
